### PR TITLE
Add srcSet generation utility functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "imgix.js",
+  "name": "@massdrop/imgix",
   "version": "3.0.2",
   "description": "imgix.js is a dependency-free JavaScript library that allows you to easily use the imgix API to make images on your site or app responsive to device size and pixel density. imgix.js allows for intuitive use of imgix features such as text formatting, color palette extraction, color adjustments, effects, and watermarking. imgix.js requires an imgix account to use your own images. Sign up at imgix.com",
-  "main": "dist/imgix.js",
+  "main": "src/index.js",
   "directories": {
     "test": "tests"
   },

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+git pull
+npm version patch
+PACKAGE=$(npm pack)
+echo PACKAGE: $PACKAGE
+curl -F package=@$PACKAGE https://C__hqNZ_HngaWmEnB-ps@push.fury.io/massdrop/
+rm $PACKAGE
+git push

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -1,5 +1,5 @@
 var util = require('./util.js'),
-    targetWidths = require('./targetWidths.js');
+    widths = require('./targetWidths.js');
 
 var ImgixTag = (function() {
   function ImgixTag(el, opts) {
@@ -134,7 +134,8 @@ var ImgixTag = (function() {
   // scaled appropriately to the same aspect ratio as the base image
   // as appropriate.
   ImgixTag.prototype.srcset = function() {
-    var pairs = [];
+    var targetWidths = widths(true),
+      pairs = [];
 
     for (var i = 0; i < targetWidths.length; i++) {
       pairs.push(this._buildSrcsetPair(targetWidths[i]));

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./srcSetUtil');

--- a/src/srcSetUtil.js
+++ b/src/srcSetUtil.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var util = require('./util.js'),
+    widths = require('./targetWidths.js');
+
+/*
+ * This functions have been copied over from ImgixTag and modified to accommodate
+ * parameters and support for watermarks. ImgixTag could be refactored to utilize
+ * these functions.
+ */
+function getBaseUrlWithoutQuery(baseUrl) {
+  return baseUrl.split('?')[0];
+};
+
+function extractBaseParams(baseUrl) {
+  var lastQuestion = baseUrl.lastIndexOf('?'),
+      paramString = baseUrl.substr(lastQuestion + 1),
+      splitParams = paramString.split('&'),
+      params = {};
+
+  for (var i = 0, splitParam; i < splitParams.length; i++) {
+    splitParam = splitParams[i].split('=');
+
+    params[splitParam[0]] = splitParam[1];
+  }
+
+  return params;
+};
+
+function buildSrcsetPair(baseUrlWithoutQuery, baseParams, targetWidth) {
+  var clonedParams = util.shallowClone(baseParams);
+  clonedParams.w = targetWidth;
+
+  if (baseParams.w) {
+    if (baseParams.h) {
+      clonedParams.h = Math.round(targetWidth * (baseParams.h / baseParams.w));
+    }
+
+    // Adjust watermark settings
+    if (baseParams.markpad) {
+      clonedParams.markpad = Math.round(targetWidth * (baseParams.markpad / baseParams.w));
+    }
+    if (baseParams.markh) {
+      clonedParams.markh = Math.round(targetWidth * (baseParams.markh / baseParams.w));
+    }
+    if (baseParams.markw) {
+      clonedParams.markw = Math.round(targetWidth * (baseParams.markw / baseParams.w));
+    }
+    if (baseParams.marky) {
+      clonedParams.marky = Math.round(targetWidth * (baseParams.marky / baseParams.w));
+    }
+    if (baseParams.markx) {
+      clonedParams.markx = Math.round(targetWidth * (baseParams.markx / baseParams.w));
+    }
+  }
+
+  var url = baseUrlWithoutQuery + '?',
+      val,
+      params = [];
+  for (var key in clonedParams) {
+    val = clonedParams[key];
+    params.push(key + '=' + val);
+  }
+
+  url += params.join('&');
+
+  return url + ' ' + targetWidth + 'w';
+};
+
+function srcset(baseUrl, useWindow) {
+  var baseUrlWithoutQuery = getBaseUrlWithoutQuery(baseUrl),
+    baseParams = extractBaseParams(baseUrl),
+    targetWidths = widths(useWindow),
+    pairs = [];
+
+  for (var i = 0; i < targetWidths.length; i++) {
+    pairs.push(buildSrcsetPair(baseUrlWithoutQuery, baseParams, targetWidths[i]));
+  }
+
+  return pairs.join(', ');
+};
+
+module.exports = {
+  getBaseUrlWithoutQuery: getBaseUrlWithoutQuery,
+  extractBaseParams: extractBaseParams,
+  buildSrcsetPair: buildSrcsetPair,
+  srcset: srcset
+};

--- a/src/targetWidths.js
+++ b/src/targetWidths.js
@@ -115,9 +115,12 @@ function screenWidths() {
 // Return the widths to generate given the input `sizes`
 // attribute.
 //
+// @param {boolean} useWindow: true if we actually want to utilize
+//    window for calculations; set to false to keep results the same
+//    when rendering on server vs client.
 // @return {Array} An array of {Fixnum} instances representing the unique `srcset` URLs to generate.
-function targetWidths() {
-  var hasWin = typeof window !== 'undefined',
+function targetWidths(useWindow) {
+  var hasWin = (typeof window !== 'undefined' && useWindow),
       allWidths = deviceWidths().concat(screenWidths()),
       selectedWidths = [],
       dpr = hasWin && window.devicePixelRatio ? window.devicePixelRatio : 1,
@@ -145,4 +148,4 @@ function targetWidths() {
   });
 }
 
-module.exports = targetWidths();
+module.exports = targetWidths;


### PR DESCRIPTION
The upstream imgix.js has support for generating a full spectrum of `srcSet` urls. This was used by selecting `<img>` DOM elements with `ix-src` attributes and adding additional `srcSet` attributes. Thus, this seems to encounter the same issue that we were hoping to avoid, where the `<img>` sources get modified, and the browser will need to fetch an image twice.

This PR copies over the main `srcSet` generation functions from `ImgixTag`, but makes them independent of instance variables. In addition, the selection of `targetWidths` now supports an option to ignore information from `window`, even if available, which we can utilize to produce an equivalent render on server and client. Lastly, support for modifying watermark parameters was added as well. 

The package was renamed to `@massdrop/imgix` per custom, and requires publishing.

An example of how this would be used in massdrop-react `ImageComponent`:

```
    imgSrc = this.context.getImage(width, height, src, transform);
    srcSet = imgix.srcset(imgSrc, false);

    return (
      <img
        {...otherProps}
        src={imgSrc}
        srcset={srcSet}
        style={_.extend({}, this.props.style, imageStyle)}
      />
    );
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/massdrop/imgix.js/1)

<!-- Reviewable:end -->
